### PR TITLE
Remove --no-cache-dir from instructions

### DIFF
--- a/resources/views/scanner-instructions.blade.php
+++ b/resources/views/scanner-instructions.blade.php
@@ -19,7 +19,7 @@ grep -Erlf grep-standard.txt /path/to/magento</code></pre></p>
 <p><h1 class="msc-block__title code"><strong>Install on Debian/Ubuntu</strong></h1></p>
 <p><pre class="prettyprint language-bash code"><code># Install prerequisites on Debian/Ubuntu flavoured server
 sudo apt install -qy python-pip gcc python-dev
-sudo pip install --no-cache-dir --upgrade mwscan</code></pre></p>
+sudo pip install --upgrade mwscan</code></pre></p>
 </p>
 <p>
 <p><h1 class="msc-block__title code"><strong>Install on Centos</strong></h1></p>
@@ -28,13 +28,13 @@ wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 sudo rpm -ivh epel-release-latest-6.noarch.rpm
 # Install prerequisites on Centos flavoured server
 sudo yum -y install python-pip python-devel gcc
-sudo pip install --no-cache-dir --upgrade mwscan </code></pre></p>
+sudo pip install --upgrade mwscan </code></pre></p>
 </p>
 <p>
 <p><h1 class="msc-block__title code"><strong>Install on OSX</strong></h1></p>
 <p><pre class="prettyprint language-bash code"><code># Install prerequisites on a Mac OSX environemnt
 brew install yara python
-sudo pip install --no-cache-dir --upgrade mwscan</code></pre></p>
+sudo pip install --upgrade mwscan</code></pre></p>
 </p>
 <p>
 <p><h1 class="msc-block__title code"><strong>Run Manually</strong></h1></p>


### PR DESCRIPTION
Older pips don't support it, only relevant for upgrading in certain cases.

Fixes #57 